### PR TITLE
Rebuild extension for PHP 7.4 support

### DIFF
--- a/relationshipjobtitle.civix.php
+++ b/relationshipjobtitle.civix.php
@@ -7,9 +7,9 @@
  * extension.
  */
 class CRM_Relationshipjobtitle_ExtensionUtil {
-  const SHORT_NAME = "relationshipjobtitle";
-  const LONG_NAME = "com.joineryhq.relationshipjobtitle";
-  const CLASS_PREFIX = "CRM_Relationshipjobtitle";
+  const SHORT_NAME = 'relationshipjobtitle';
+  const LONG_NAME = 'com.joineryhq.relationshipjobtitle';
+  const CLASS_PREFIX = 'CRM_Relationshipjobtitle';
 
   /**
    * Translate a string using the extension's domain.
@@ -91,9 +91,9 @@ function _relationshipjobtitle_civix_civicrm_config(&$config = NULL) {
   }
   $configured = TRUE;
 
-  $template =& CRM_Core_Smarty::singleton();
+  $template = CRM_Core_Smarty::singleton();
 
-  $extRoot = dirname(__FILE__) . DIRECTORY_SEPARATOR;
+  $extRoot = __DIR__ . DIRECTORY_SEPARATOR;
   $extDir = $extRoot . 'templates';
 
   if (is_array($template->template_dir)) {
@@ -221,7 +221,8 @@ function _relationshipjobtitle_civix_upgrader() {
  * Search directory tree for files which match a glob pattern.
  *
  * Note: Dot-directories (like "..", ".git", or ".svn") will be ignored.
- * Note: In Civi 4.3+, delegate to CRM_Utils_File::findFiles()
+ * Note: Delegate to CRM_Utils_File::findFiles(), this function kept only
+ * for backward compatibility of extension code that uses it.
  *
  * @param string $dir base dir
  * @param string $pattern , glob pattern, eg "*.txt"
@@ -229,32 +230,7 @@ function _relationshipjobtitle_civix_upgrader() {
  * @return array
  */
 function _relationshipjobtitle_civix_find_files($dir, $pattern) {
-  if (is_callable(['CRM_Utils_File', 'findFiles'])) {
-    return CRM_Utils_File::findFiles($dir, $pattern);
-  }
-
-  $todos = [$dir];
-  $result = [];
-  while (!empty($todos)) {
-    $subdir = array_shift($todos);
-    foreach (_relationshipjobtitle_civix_glob("$subdir/$pattern") as $match) {
-      if (!is_dir($match)) {
-        $result[] = $match;
-      }
-    }
-    if ($dh = opendir($subdir)) {
-      while (FALSE !== ($entry = readdir($dh))) {
-        $path = $subdir . DIRECTORY_SEPARATOR . $entry;
-        if ($entry[0] == '.') {
-        }
-        elseif (is_dir($path)) {
-          $todos[] = $path;
-        }
-      }
-      closedir($dh);
-    }
-  }
-  return $result;
+  return CRM_Utils_File::findFiles($dir, $pattern);
 }
 
 /**


### PR DESCRIPTION
Extension is outdated and throw error in PHP 7.4

PHP Deprecated: Array and string offset access syntax with curly braces is deprecated

FIX: rebuild files with built in function civix generate:module